### PR TITLE
Default root key for as_json to be false

### DIFF
--- a/app/controllers/rsvp_controller.rb
+++ b/app/controllers/rsvp_controller.rb
@@ -2,6 +2,9 @@ class RsvpController < ApplicationController
   def show
     code = params[:code]
     @user_group = UserGroup.find_by_code(code)
+
+    ActiveRecord::Base.include_root_in_json = false
+
     respond_to do |format|
       # format.html { render :action => :update }
       format.json {


### PR DESCRIPTION
to: @lxwyndxl

Rails 3 defaults root key to `true` then Rails 3.1 defaults it to `false` again

``` javascript
{
  "user_group": {
    "address_line1": "1 Mansion Drive",
    "address_line2": "",
    "city": "Baoville",
    "code": "TEST",
    "created_at": "2016-01-31T00:53:52Z",
    "id": 1,
    "lodging_friday": null,
    "lodging_saturday": null,
    "lodging_sunday": null,
    "notes": "test notes",
    "state": "CA",
    "tier": 0,
    "updated_at": "2016-10-17T02:31:53Z",
    "zipcode": "12345"
  },
  "users": [
    {
      "created_at": "2016-01-31T01:00:27Z",
      "diet": "1",
      "email": "test@gmail.com",
      "first_name": "Baozi",
      "id": 1,
      "is_attending": true,
      "last_name": "Test",
      "role": 1,
      "updated_at": "2016-10-17T02:31:53Z",
      "user_group_id": 1
    },
    {
      "created_at": "2016-10-09T08:01:24Z",
      "diet": "0",
      "email": "newemail",
      "first_name": "a",
      "id": 2,
      "is_attending": false,
      "last_name": "b",
      "role": null,
      "updated_at": "2016-10-16T22:43:00Z",
      "user_group_id": 1
    }
  ]
}
```
