### PR TITLE
Add Gemfile.lock for heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     pundit (0.2.3)
       activesupport (>= 3.0.0)
     rack (1.2.8)
+    rack-cors (0.4.0)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
     rack-test (0.5.7)
@@ -77,6 +78,7 @@ PLATFORMS
 
 DEPENDENCIES
   pundit
+  rack-cors
   rails (= 3.0.20)
   sqlite3
 


### PR DESCRIPTION
```
-----> Installing dependencies using bundler 1.13.6
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       You are trying to install in deployment mode after changing
       your Gemfile. Run `bundle install` elsewhere and add the
       updated Gemfile.lock to version control.
       You have added to the Gemfile:
       * rack-cors
       Bundler Output: You are trying to install in deployment mode after changing
       your Gemfile. Run `bundle install` elsewhere and add the
       updated Gemfile.lock to version control.
       
       You have added to the Gemfile:
       * rack-cors
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```