### PR TITLE
Set default false and empty string values for user and user group

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,18 @@ class User < ActiveRecord::Base
   belongs_to :user_group
   validates :first_name, :last_name, presence: true
   attr_accessible :diet, :email, :is_attending, :first_name, :last_name, :role
+
+  def as_json(options={})
+    hash = super(options)
+    hash['is_attending'] = hash['is_attending'] == true
+    hash['first_name'] = default_empty_strings(hash['first_name'])
+    hash['last_name'] = default_empty_strings(hash['last_name'])
+    hash['email'] = default_empty_strings(hash['email'])
+    hash
+  end
+
+  private
+  def default_empty_strings(value)
+    value.blank? ? '' : value
+  end
 end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -2,4 +2,16 @@ class UserGroup < ActiveRecord::Base
   has_many :users
   accepts_nested_attributes_for :users
   belongs_to :lodgings, :foreign_key => 'room_number'
+
+  def as_json(options={})
+    hash = super(options)
+    hash['lodging_saturday'] = default_false(hash['lodging_saturday'])
+    hash['lodging_sunday'] = default_false(hash['lodging_sunday'])
+    hash
+  end
+
+  private
+  def default_false(value)
+    value.blank? ? false : value
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Wedding::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_view.debug_rjs             = true
+  # config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send


### PR DESCRIPTION
bleh. null values were not being saved as false unless they were explicitly checked or unchecked in the UI. Instead, send them down as false the UI doesn't need to do the logic - whenever a submit happens, all attending value should be non null.

@lxwyndxl 